### PR TITLE
Use token from auth header unless query string token exists

### DIFF
--- a/src/ingress-nginx-validate-jwt-tests/EndToEndBase.cs
+++ b/src/ingress-nginx-validate-jwt-tests/EndToEndBase.cs
@@ -10,7 +10,7 @@ namespace ingress_nginx_validate_jwt_tests
         public EndToEndBase()
         {
             container = new ContainerBuilder()
-              .WithImage("ivanjosipovic/ingress-nginx-validate-jwt")
+              .WithImage("ingress-nginx-validate-jwt")
               .WithEnvironment("OpenIdProviderConfigurationUrl", "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration")
               .WithPortBinding(8080)
               .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8080))

--- a/src/ingress-nginx-validate-jwt-tests/EndToEndBase.cs
+++ b/src/ingress-nginx-validate-jwt-tests/EndToEndBase.cs
@@ -10,7 +10,7 @@ namespace ingress_nginx_validate_jwt_tests
         public EndToEndBase()
         {
             container = new ContainerBuilder()
-              .WithImage("ingress-nginx-validate-jwt")
+              .WithImage("ivanjosipovic/ingress-nginx-validate-jwt")
               .WithEnvironment("OpenIdProviderConfigurationUrl", "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration")
               .WithPortBinding(8080)
               .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(8080))

--- a/src/ingress-nginx-validate-jwt/Controllers/AuthController.cs
+++ b/src/ingress-nginx-validate-jwt/Controllers/AuthController.cs
@@ -132,7 +132,7 @@ public class AuthController : ControllerBase
         {
             var builder = new UriBuilder(originalUrl);
             var queryParams = HttpUtility.ParseQueryString(builder.Query);
-            token = queryParams[QueryParameters.AccessToken];
+            token ??= queryParams[QueryParameters.AccessToken];
         }
 
         return token;


### PR DESCRIPTION
The change from #71 caused tokens from the Authorization header to be overwritten by the token from the query string, or, if there were none as a query string, replaced with an empty string, causing auth to fail despite providing an authorized token.

This change will preserve the token from the header, only overwriting it if a token is provided in a query string.

I added a unit test, but had trouble running it, it just timed out.