### PR TITLE
Add option to disable SSL verification for IDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Tar.gz files for helm chart
+*.tgz

--- a/charts/ingress-nginx-validate-jwt/templates/deployment.yaml
+++ b/charts/ingress-nginx-validate-jwt/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
             value: "{{ .Values.openIdProviderConfigurationUrl }}"
           - name: "Logging__LogLevel__Default"
             value: "{{ .Values.logLevel }}"
+          - name: "disableSslVerification"
+            value: "{{ .Values.disableSslVerification }}"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/ingress-nginx-validate-jwt/values.yaml
+++ b/charts/ingress-nginx-validate-jwt/values.yaml
@@ -20,6 +20,9 @@ openIdProviderConfigurationUrl: "https://login.microsoftonline.com/common/v2.0/.
 # Log Level(Trace, Debug, Information, Warning, Error, Critical, and None)
 logLevel: Information
 
+# SSL verification
+disableSslVerification: false
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Hi,

One project required using Keycloak as IDP, but SSL is internal and signed by internal SSL authority.
To avoid adding CA certs in the container, I think that it would be good to have the option to disable SSL verification.

By default, I disabled this option in helm chart.

Please let me know if I need to do something else to merge this PR :)